### PR TITLE
Add a new fuzz input data for FuzzParse in github.com/shogo82148/fowa…

### DIFF
--- a/forwarded.go
+++ b/forwarded.go
@@ -47,7 +47,7 @@ func (n Node) write(buf *strings.Builder) {
 	} else {
 		if n.IP.Is6() {
 			buf.WriteByte('[')
-			buf.WriteString(n.IP.String())
+			buf.WriteString(n.IP.WithZone("").String())
 			buf.WriteByte(']')
 		} else {
 			buf.WriteString(n.IP.String())
@@ -533,6 +533,9 @@ func (p *parser) parseNode(s string) (Node, error) {
 		if err != nil {
 			return Node{}, err
 		}
+		if ip.Zone() != "" {
+			return Node{}, p.newError("unexpected zone identifier")
+		}
 		n.IP = ip
 	} else {
 		// ipv4
@@ -545,6 +548,9 @@ func (p *parser) parseNode(s string) (Node, error) {
 		}
 		if err != nil {
 			return Node{}, err
+		}
+		if ip.Zone() != "" {
+			return Node{}, p.newError("unexpected zone identifier")
 		}
 		n.IP = ip
 	}

--- a/fowarded_test.go
+++ b/fowarded_test.go
@@ -334,6 +334,12 @@ func TestParse_Error(t *testing.T) {
 				`for=192.0.2.1; for="[2001:db8:cafe::17]"`,
 			},
 		},
+		{
+			name: "issue-10",
+			headers: []string{
+				"For=\"::%]:00\"",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/testdata/fuzz/FuzzParse/e5d1d4cde8dae165
+++ b/testdata/fuzz/FuzzParse/e5d1d4cde8dae165
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("For=\"::%]:00\"")


### PR DESCRIPTION
…rded-header.

fuzzing failed with the following output:

```
--- FAIL: FuzzParse (27.11s)
    --- FAIL: FuzzParse (0.00s)
        fowarded_test.go:309: "for=\"[::%]]\"": ParseAddr("::%"): zone must be a non-empty string
        fowarded_test.go:314: Parse() mismatch (-want +got):
              []*fowardedheader.Forwarded(
            - 	{s`for="[::%]]"`},
            + 	nil,
              )
    
    Failing input written to testdata/fuzz/FuzzParse/e5d1d4cde8dae165
    To re-run:
    go test -run=FuzzParse/e5d1d4cde8dae165
FAIL
exit status 1
FAIL	github.com/shogo82148/fowarded-header	27.110s

```

The result of `go test -run=FuzzParse/e5d1d4cde8dae165 github.com/shogo82148/fowarded-header` is:

```
--- FAIL: FuzzParse (0.00s)
    --- FAIL: FuzzParse/e5d1d4cde8dae165 (0.00s)
        fowarded_test.go:309: "for=\"[::%]]\"": ParseAddr("::%"): zone must be a non-empty string
        fowarded_test.go:314: Parse() mismatch (-want +got):
              []*fowardedheader.Forwarded(
            - 	{s`for="[::%]]"`},
            + 	nil,
              )
FAIL
FAIL	github.com/shogo82148/fowarded-header	0.002s
FAIL

```

This fuzz data is generated by [actions-go-fuzz](https://github.com/shogo82148/actions-go-fuzz).